### PR TITLE
[11.0][FIX] purchase_batch_invoicing invoice_status added twice

### DIFF
--- a/purchase_batch_invoicing/views/purchase_order_view.xml
+++ b/purchase_batch_invoicing/views/purchase_order_view.xml
@@ -19,15 +19,4 @@
         </field>
     </record>
 
-    <record id="purchase_order_tree" model="ir.ui.view">
-        <field name="name">Show invoice status in PO tree</field>
-        <field name="model">purchase.order</field>
-        <field name="inherit_id" ref="purchase.purchase_order_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='state']" position="after">
-                <field name="invoice_status"/>
-            </xpath>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
No need to add invoice_status in tree view as it's already there in purchase.purchase_order_tree